### PR TITLE
ci: add linter action on prs & main pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

another warmup pr for my day :coffee:

smol followup to #29 to help make sure any outside contribs have linted their branches

this concise notation was recommended in [the official ruff docs](https://docs.astral.sh/ruff/integrations/#github-actions) but i can see an argument for doing it the slightly more verbose way (with setup python -> setup poetry -> run ruff) so that eventually a pytest step & a typechecker could slot in -- happy to change if thats more the direction ya wanna take

## Testing

gh actions settings might need tweaked for the repo before it runs here

ran the action locally first with `nektos/act` anyway.  here's what an improperly sorted import block would look like (better in the gh ui, but ya get the gist)

```sh
$ act pull_request
[Lint/ruff] 🚀  Start image=catthehacker/ubuntu:act-latest
INFO[0000] Parallel tasks (0) below minimum, setting to 1 
[Lint/ruff]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
INFO[0000] Parallel tasks (0) below minimum, setting to 1 
[Lint/ruff]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Lint/ruff]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Lint/ruff]   ☁  git clone 'https://github.com/chartboost/ruff-action' # ref=v1
[Lint/ruff] ⭐ Run Pre chartboost/ruff-action@v1
[Lint/ruff]   ✅  Success - Pre chartboost/ruff-action@v1
[Lint/ruff] ⭐ Run Main actions/checkout@v3
[Lint/ruff]   🐳  docker cp src=/home/sam/dev/openrouter-runner/. dst=/home/sam/dev/openrouter-runner
[Lint/ruff]   ✅  Success - Main actions/checkout@v3
[Lint/ruff] ⭐ Run Main chartboost/ruff-action@v1
[Lint/ruff]   🐳  docker cp src=/home/sam/.cache/act/chartboost-ruff-action@v1/ dst=/var/run/act/actions/chartboost-ruff-action@v1/
[Lint/ruff] ⭐ Run Main if [ "$RUNNER_OS" == "Windows" ]; then
  python $GITHUB_ACTION_PATH/action/main.py
else
  python3 $GITHUB_ACTION_PATH/action/main.py
fi
[Lint/ruff]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/1-composite-0.sh] user= workdir=
| creating virtual environment...
| creating shared libraries...
| upgrading shared libraries...
| installing ruff...
| modal/runner/__init__.py:1:1: I001 [*] Import block is un-sorted or un-formatted
| Found 1 error.
| [*] 1 fixable with the `--fix` option.
[Lint/ruff]   ❌  Failure - Main if [ "$RUNNER_OS" == "Windows" ]; then
  python $GITHUB_ACTION_PATH/action/main.py
else
  python3 $GITHUB_ACTION_PATH/action/main.py
fi
[Lint/ruff] exitcode '1': failure
[Lint/ruff]   ❌  Failure - Main chartboost/ruff-action@v1
[Lint/ruff] exitcode '1': failure
[Lint/ruff] ⭐ Run Post chartboost/ruff-action@v1
[Lint/ruff]   🐳  docker cp src=/home/sam/.cache/act/chartboost-ruff-action@v1/ dst=/var/run/act/actions/chartboost-ruff-action@v1/
[Lint/ruff]   ✅  Success - Post chartboost/ruff-action@v1
[Lint/ruff] 🏁  Job failed
Error: Job 'ruff' failed
```

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
