### PR TITLE
fix: dedupe auth logic & patch potential timing attack

### DIFF
--- a/modal/punctuator/__init__.py
+++ b/modal/punctuator/__init__.py
@@ -1,5 +1,4 @@
 import os
-from typing import Annotated
 
 from fastapi import Depends
 from fastapi.responses import StreamingResponse
@@ -38,7 +37,9 @@ def download_models():
 _gpu = gpu.A10G(count=1)
 _image = (
     Image.from_registry("nvcr.io/nvidia/pytorch:22.12-py3")
-    .pip_install("torch==2.0.1+cu118", index_url="https://download.pytorch.org/whl/cu118")
+    .pip_install(
+        "torch==2.0.1+cu118", index_url="https://download.pytorch.org/whl/cu118"
+    )
     .pip_install("sentencepiece")
     .pip_install("deepmultilingualpunctuation")
     .pip_install("hf-transfer~=0.1")
@@ -72,12 +73,16 @@ class Punctuator:
         import threading
         import time
 
-        output = [None]  # Use a list to hold the output to bypass Python's scoping limitations
+        output = [
+            None
+        ]  # Use a list to hold the output to bypass Python's scoping limitations
         output_ready = threading.Event()
 
         def punctuate_thread():
             try:
-                output[0] = create_response_text(self.model.restore_punctuation(input_str))
+                output[0] = create_response_text(
+                    self.model.restore_punctuation(input_str)
+                )
             except Exception as err:
                 output[0] = create_error_text(err)
                 print(output[0])
@@ -103,7 +108,7 @@ class Punctuator:
 @web_endpoint(method="POST")
 def punct(
     payload: Payload,
-    _token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)],
+    _token: HTTPAuthorizationCredentials = Depends(config.auth),
 ):
     p = Punctuator()
 

--- a/modal/runner/endpoints/completion.py
+++ b/modal/runner/endpoints/completion.py
@@ -1,8 +1,8 @@
-import os
+from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, status
 from fastapi.responses import StreamingResponse
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from runner.containers import get_container
 from runner.shared.common import BACKLOG_THRESHOLD, config
 from runner.shared.sampling_params import SamplingParams
@@ -11,20 +11,11 @@ from shared.protocol import (
     create_error_response,
 )
 
-auth_scheme = HTTPBearer()
-
 
 def completion(
     payload: Payload,
-    token: HTTPAuthorizationCredentials = Depends(auth_scheme),
+    _token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)],
 ):
-    if token.credentials != os.environ[config.api_key_id]:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect bearer token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
     try:
         runner = get_container(payload.model)
         stats = runner.generate.get_current_stats()

--- a/modal/runner/endpoints/completion.py
+++ b/modal/runner/endpoints/completion.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 from fastapi import Depends, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials
@@ -14,7 +12,7 @@ from shared.protocol import (
 
 def completion(
     payload: Payload,
-    _token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)],
+    _token: HTTPAuthorizationCredentials = Depends(config.auth),
 ):
     try:
         runner = get_container(payload.model)

--- a/modal/runner/shared/clean.py
+++ b/modal/runner/shared/clean.py
@@ -3,8 +3,12 @@ from typing import List
 
 from shared.volumes import get_model_path, models_path
 
+from .common import stub
+
 
 def clean_models_volume(all_models: List[str], dry: bool = True):
+    import shutil
+
     # go through each directory in the models volume
     for author in os.listdir(models_path):
         if author == "__cache__":
@@ -18,6 +22,9 @@ def clean_models_volume(all_models: List[str], dry: bool = True):
                 model_path = get_model_path(model_id)
                 print(f"    Removing {model_path}")
                 if not dry:
-                    os.rmdir(model_path)
-
+                    shutil.rmtree(model_path, ignore_errors=True)
+    
+    if not dry:
+        stub.models_volume.commit()
+    
     print("ALL DONE!")

--- a/modal/runner/shared/download.py
+++ b/modal/runner/shared/download.py
@@ -48,7 +48,7 @@ def download_models(all_models: List[str]):
                 cache_dir=cache_path,
                 token=env["HUGGINGFACE_TOKEN"],
             )
-            print(f"Volume contains {model_name}.")
+            print(f"Volume contains {model_name}")
         except FileNotFoundError:
             print(f"Downloading {model_name} ...")
             snapshot_download(

--- a/modal/shap-e/__init__.py
+++ b/modal/shap-e/__init__.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import List, Optional
 
 from fastapi import Depends
 from fastapi.responses import StreamingResponse
@@ -87,7 +87,9 @@ class Model:
         import threading
         import time
 
-        output = [None]  # Use a list to hold the output to bypass Python's scoping limitations
+        output = [
+            None
+        ]  # Use a list to hold the output to bypass Python's scoping limitations
         output_ready = threading.Event()
 
         def make_object():
@@ -128,10 +130,18 @@ class Model:
                     buffer.seek(0)
 
                     # Encode the buffer content to base64
-                    base64_data = base64.b64encode(buffer.read()).decode("utf-8")
-                    outputs.append(Generation(uri=f"data:application/x-ply;base64,{base64_data}"))
+                    base64_data = base64.b64encode(buffer.read()).decode(
+                        "utf-8"
+                    )
+                    outputs.append(
+                        Generation(
+                            uri=f"data:application/x-ply;base64,{base64_data}"
+                        )
+                    )
 
-                output[0] = ResponseBody(outputs=outputs).json(ensure_ascii=False)
+                output[0] = ResponseBody(outputs=outputs).json(
+                    ensure_ascii=False
+                )
 
             except Exception as err:
                 output[0] = create_error_text(err)
@@ -155,7 +165,7 @@ class Model:
 @web_endpoint(method="POST")
 def create(
     payload: Payload,
-    _token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)],
+    _token: HTTPAuthorizationCredentials = Depends(config.auth),
 ):
     p = Model()
 

--- a/modal/shared/config.py
+++ b/modal/shared/config.py
@@ -18,7 +18,9 @@ class Config(BaseModel):
         API Authentication dependency for protected endpoints. Checks that the request's bearer token
         matches the server's configured API key.
 
-        Raises: HTTPException(401) if the token is invalid.
+        Raises:
+            * HTTPException(403) if no token is provided.
+            * HTTPException(401) if the token is invalid.
         """
 
         # Timing attacks possible through direct comparison. Prevent it with a constant time comparison here.

--- a/modal/shared/config.py
+++ b/modal/shared/config.py
@@ -1,6 +1,28 @@
+import os
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
+
+_auth = HTTPBearer()
 
 
 class Config(BaseModel):
     name: str
     api_key_id: str
+
+    def auth(self, token: Annotated[HTTPAuthorizationCredentials, Depends(_auth)]) -> HTTPAuthorizationCredentials:
+        """
+        API Authentication dependency for protected endpoints. Checks that the request's bearer token
+        matches the server's configured API key.
+
+        Raises: HTTPException(401) if the token is invalid.
+        """
+        if token.credentials != os.environ[self.api_key_id]:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Incorrect bearer token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        return token

--- a/modal/shared/config.py
+++ b/modal/shared/config.py
@@ -1,6 +1,5 @@
 import os
 import secrets
-from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -13,7 +12,9 @@ class Config(BaseModel):
     name: str
     api_key_id: str
 
-    def auth(self, token: Annotated[HTTPAuthorizationCredentials, Depends(_auth)]) -> HTTPAuthorizationCredentials:
+    def auth(
+        self, token: HTTPAuthorizationCredentials = Depends(_auth)
+    ) -> HTTPAuthorizationCredentials:
         """
         API Authentication dependency for protected endpoints. Checks that the request's bearer token
         matches the server's configured API key.

--- a/modal/shared/test_config.py
+++ b/modal/shared/test_config.py
@@ -1,0 +1,29 @@
+import os
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, testclient
+from fastapi.security import HTTPAuthorizationCredentials
+
+from shared.config import Config
+
+
+def test_auth():
+    """The API auth dependency should prevent unauthorized requests."""
+
+    app = FastAPI()
+    config = Config(name="test", api_key_id="RUNNER_API_KEY")
+    os.environ["RUNNER_API_KEY"] = "abc123"
+
+    @app.get("/test")
+    def test(_token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)]):
+        return "OK"
+
+    with testclient.TestClient(app) as client:
+        response = client.get("/test")
+        assert response.status_code == 403
+
+        response = client.get("/test", headers={"Authorization": "Bearer invalid"})
+        assert response.status_code == 401
+
+        response = client.get("/test", headers={"Authorization": "Bearer abc123"})
+        assert response.status_code == 200

--- a/modal/shared/test_config.py
+++ b/modal/shared/test_config.py
@@ -1,5 +1,4 @@
 import os
-from typing import Annotated
 
 from fastapi import Depends, FastAPI, testclient
 from fastapi.security import HTTPAuthorizationCredentials
@@ -15,15 +14,19 @@ def test_auth():
     os.environ["RUNNER_API_KEY"] = "abc123"
 
     @app.get("/test")
-    def test(_token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)]):
+    def test(_token: HTTPAuthorizationCredentials = Depends(config.auth)):
         return "OK"
 
     with testclient.TestClient(app) as client:
         response = client.get("/test")
         assert response.status_code == 403
 
-        response = client.get("/test", headers={"Authorization": "Bearer invalid"})
+        response = client.get(
+            "/test", headers={"Authorization": "Bearer invalid"}
+        )
         assert response.status_code == 401
 
-        response = client.get("/test", headers={"Authorization": "Bearer abc123"})
+        response = client.get(
+            "/test", headers={"Authorization": "Bearer abc123"}
+        )
         assert response.status_code == 200

--- a/modal/tuner/endpoints/create_lora.py
+++ b/modal/tuner/endpoints/create_lora.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 from fastapi import Depends
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials
@@ -7,7 +5,7 @@ from tuner.containers.mistral_7b_lora import Mistral7BLoraContainer
 from tuner.shared.common import config
 
 
-def create_lora(_token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)]):
+def create_lora(_token: HTTPAuthorizationCredentials = Depends(config.auth)):
     tuner = Mistral7BLoraContainer()
     return StreamingResponse(
         tuner.generate.remote_gen(),

--- a/modal/tuner/endpoints/create_lora.py
+++ b/modal/tuner/endpoints/create_lora.py
@@ -1,23 +1,13 @@
-import os
+from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends
 from fastapi.responses import StreamingResponse
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from tuner.containers.mistral_7b_lora import Mistral7BLoraContainer
 from tuner.shared.common import config
 
-auth_scheme = HTTPBearer()
 
-
-def create_lora(
-    token: HTTPAuthorizationCredentials = Depends(auth_scheme),
-):
-    if token.credentials != os.environ[config.api_key_id]:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect bearer token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+def create_lora(_token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)]):
     tuner = Mistral7BLoraContainer()
     return StreamingResponse(
         tuner.generate.remote_gen(),

--- a/modal/tuner/endpoints/list_lora.py
+++ b/modal/tuner/endpoints/list_lora.py
@@ -1,5 +1,4 @@
 import os
-from typing import Annotated
 
 from fastapi import Depends, status
 from fastapi.responses import JSONResponse
@@ -8,7 +7,7 @@ from shared.volumes import loras_path
 from tuner.shared.common import config
 
 
-def list_lora(_token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)]):
+def list_lora(_token: HTTPAuthorizationCredentials = Depends(config.auth)):
     # Get all files from the loras volume
 
     files = os.listdir(loras_path)

--- a/modal/tuner/endpoints/list_lora.py
+++ b/modal/tuner/endpoints/list_lora.py
@@ -1,23 +1,14 @@
 import os
+from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, status
 from fastapi.responses import JSONResponse
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from shared.volumes import loras_path
 from tuner.shared.common import config
 
-auth_scheme = HTTPBearer()
 
-
-def list_lora(
-    token: HTTPAuthorizationCredentials = Depends(auth_scheme),
-):
-    if token.credentials != os.environ[config.api_key_id]:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect bearer token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+def list_lora(_token: Annotated[HTTPAuthorizationCredentials, Depends(config.auth)]):
     # Get all files from the loras volume
 
     files = os.listdir(loras_path)

--- a/poetry.lock
+++ b/poetry.lock
@@ -722,6 +722,17 @@ multidict = "*"
 protobuf = ["protobuf (>=3.15.0)"]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
 name = "h2"
 version = "4.1.0"
 description = "HTTP/2 State-Machine based protocol implementation"
@@ -746,6 +757,51 @@ files = [
     {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
     {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "1.0.2"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.2-py3-none-any.whl", hash = "sha256:096cc05bca73b8e459a1fc3dcf585148f63e534eae4339559c9b8a8d6399acc7"},
+    {file = "httpcore-1.0.2.tar.gz", hash = "sha256:9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<0.23.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.26.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
+    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "huggingface-hub"
@@ -834,6 +890,17 @@ zipp = ">=0.5"
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
 
 [[package]]
 name = "jinja2"
@@ -1323,6 +1390,21 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
+name = "pluggy"
+version = "1.3.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pre-commit"
 version = "3.6.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -1586,6 +1668,28 @@ files = [
 
 [package.extras]
 plugins = ["importlib-metadata"]
+
+[[package]]
+name = "pytest"
+version = "7.4.3"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
+    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -2388,6 +2492,17 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "torch"
 version = "2.1.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
@@ -2964,4 +3079,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "7293a8b45f3926365eec2b827316c05b4e4dfc02cfd50b89bc834cefa991a0dc"
+content-hash = "8654311c1daa1eb66a7818c4e3cbd36ae5365d20ecb0553746883a41f1b2db08"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3079,4 +3079,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "8654311c1daa1eb66a7818c4e3cbd36ae5365d20ecb0553746883a41f1b2db08"
+content-hash = "c071d9226cf9a6cbb6c553260c11b7da2a2ea67be3f022db1df08a3308d19323"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-line-length = 120
+line-length = 80
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,13 @@ accelerate = "^0.23.0"
 datasets = "^2.14.5"
 scipy = "^1.11.3"
 wandb = "^0.15.12"
+httpx = "^0.26.0"
 
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.1.9"
 pre-commit = "^3.6.0"
+pytest = "^7.4.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,12 @@ accelerate = "^0.23.0"
 datasets = "^2.14.5"
 scipy = "^1.11.3"
 wandb = "^0.15.12"
-httpx = "^0.26.0"
-
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.1.9"
 pre-commit = "^3.6.0"
 pytest = "^7.4.3"
+httpx = "^0.26.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/shared.ts
+++ b/scripts/shared.ts
@@ -16,10 +16,11 @@ export async function completion(
     model = defaultModel,
     max_tokens = 16,
     stream = false,
-    stop = ['</s>']
+    stop = ['</s>'],
+    apiKey = key
   } = {}
 ) {
-  if (!url || !key) {
+  if (!url || !apiKey) {
     throw new Error('Missing url or key');
   }
 
@@ -27,7 +28,7 @@ export async function completion(
     id: Math.random().toString(36).substring(7),
     prompt,
     model,
-    params: { max_tokens, stop },
+    params: {max_tokens, stop},
     stream
   };
 
@@ -35,7 +36,7 @@ export async function completion(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${key}`
+      Authorization: `Bearer ${apiKey}`
     },
     body: JSON.stringify(bodyPayload)
   });
@@ -46,6 +47,10 @@ export async function completion(
   } else {
     const output = await p.text();
     console.log(output);
+  }
+
+  if (!p.ok) {
+    throw new Error(`Status: ${p.status}`);
   }
 }
 

--- a/scripts/test-simple.ts
+++ b/scripts/test-simple.ts
@@ -15,6 +15,17 @@ async function main(model?: string) {
     max_tokens: 1024,
     stop: ['</s>'],
   });
+
+  // Unauthorized requests should fail with a 401
+  let gotExpectedError = false;
+  try {
+      await completion(prompt, {model, apiKey: "BADKEY"});
+  } catch (e: any) {
+    gotExpectedError = e.message == "Status: 401";
+  }
+  if (!gotExpectedError) {
+    throw new Error("Unauthorized request returned unexpected response")
+  }
 }
 
 runIfCalledAsScript(main, import.meta.url);


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

'splorin the codebase a bit more, and saw a simple refactor to share that auth logic across endpoints

haven't used fastapi in a little while, so when i went to check latest syntax on dependencies/middleware, i saw they recommend the new `Annotated[...]` style in python 3.10+

you can find the rationale behind a lot of the structuring [in the docs here](https://fastapi.tiangolo.com/advanced/security/http-basic-auth) -- including their notes on the possible timing attack

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
