### PR TITLE
perf: try completion stub async to avoid many new threads

### DIFF
--- a/modal/runner/endpoints/completion.py
+++ b/modal/runner/endpoints/completion.py
@@ -11,7 +11,7 @@ from shared.protocol import (
 )
 
 
-def completion(
+async def completion(
     payload: Payload,
     _token: HTTPAuthorizationCredentials = Depends(config.auth),
 ):


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

followup to 265cdee83207b76ce1f4c5f867ee7c1db5af96c9

assuming the above hotfix shows some promising progress, we could do a quick experiment inspired from [their concurrent-input docs](https://modal.com/docs/guide/concurrent-inputs?#configuring-concurrent-inputs)

looking to observe any resource util diff between the  current sync stub (many threads scheduled separately) vs an async stub (one thread, separate async tasks)

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
