### PR TITLE
deps: bump vllm from 0.2.6 to 0.2.7

### DIFF
--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -12,7 +12,7 @@ from shared.volumes import does_model_exist, models_path, models_volume
 _vllm_image = Image.from_registry(
     "nvidia/cuda:12.1.0-base-ubuntu22.04",
     add_python="3.10",
-).pip_install("vllm==0.2.6", "sentry-sdk==1.39.1")
+).pip_install("vllm==0.2.7", "sentry-sdk==1.39.1")
 
 
 def _make_container(


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->
https://github.com/vllm-project/vllm/releases/tag/v0.2.7

```
* Up to 70% throughput improvement for distributed inference by removing serialization/deserialization overheads
* Fix tensor parallelism support for Mixtral + GPTQ/AWQ
```

believe only the second point would have an impact (unless the `ray` usage when num_gpu > 1 is also considered "distributed inference" even if on the same "machine" in modal?)

but probs worth keeping up with it anyhow

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
