### PR TITLE
fix: report generation errors to sentry w/ model name

### DIFF
--- a/modal/runner/engines/vllm.py
+++ b/modal/runner/engines/vllm.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from modal import method
@@ -44,12 +45,12 @@ class VllmEngine(BaseEngine):
         from vllm.engine.arg_utils import AsyncEngineArgs
         from vllm.engine.async_llm_engine import AsyncLLMEngine
 
-        engine_args = AsyncEngineArgs(
+        self.engine_args = AsyncEngineArgs(
             **params.dict(),
             disable_log_requests=True,
         )
 
-        self.engine = AsyncLLMEngine.from_engine_args(engine_args)
+        self.engine = AsyncLLMEngine.from_engine_args(self.engine_args)
 
     # @method()
     # async def tokenize_prompt(self, payload: Payload) -> List[int]:
@@ -116,7 +117,9 @@ class VllmEngine(BaseEngine):
             print(f"Request completed: {throughput:.4f} tokens/s")
         except Exception as err:
             e = create_error_text(err)
-            print(e)
+            logging.exception(
+                "Failed generation", extra={"model": self.engine_args.model}
+            )
             if payload.stream:
                 yield create_sse_data(e)
             else:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

previously, any errors during the `generate(` method would only get printed

because the `sentry_sdk` is already initialized by the time this logic is hit, we can use `logging.exception(` to bubble up to sentry

the log entry in modal will be more visible with the ERROR level, and automatically includes the stack trace because of the `.exception(` use instead of plain `.error(`
![image](https://github.com/OpenRouterTeam/openrouter-runner/assets/1211977/34bf6cea-036c-4639-ac24-9ce85488538a)

additionally, i've included the model in the extra params.  doesn't look like it shows in modal but it will show in datadog once thats hooked up.  its already visible in [the sentry error](https://openrouter.sentry.io/issues/4855122459/?environment=development&project=4506519497998336&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0) tho:

![image](https://github.com/OpenRouterTeam/openrouter-runner/assets/1211977/2aaaa9a6-2344-4c6b-920c-0986994ef712)


### Code of Conduct

- [ ] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I agree to license this contribution under the MIT LICENSE
- [ ] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
