### PR TITLE
fix: revert use of @enter entrypoint due to bug

### DIFF
--- a/modal/runner/engines/vllm.py
+++ b/modal/runner/engines/vllm.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from modal import enter, method
+from modal import method
 from pydantic import BaseModel
 
 from shared.logging import get_logger, timer
@@ -52,11 +52,6 @@ class VllmEngine(BaseEngine):
             **params.dict(),
             disable_log_requests=True,
         )
-        self.engine: AsyncLLMEngine | None = None
-
-    @enter()
-    def start(self):
-        from vllm.engine.async_llm_engine import AsyncLLMEngine
 
         with timer("engine init", tags={"model": self.engine_args.model}):
             self.engine = AsyncLLMEngine.from_engine_args(self.engine_args)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->
not seeing the engine initialize for any other models in the stats
![image](https://github.com/OpenRouterTeam/openrouter-runner/assets/1211977/a28e0c87-332b-4f35-b6c2-d57eada03dfb)


even when i've explicitly sent a chat for neuralchat in the playground, saw request come in, but engine never started. just idles in UI

![image](https://github.com/OpenRouterTeam/openrouter-runner/assets/1211977/12062394-ce61-4eb3-b429-9dc4cec6ff36)


i have a suspicion that the `@enter` hook has some bug/unspecified behavior when used with a parametrized class in modal

this fix would return things to before that experiment, just to check

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
