### PR TITLE
ci: temporarily disable downloading models in CI, only deploy

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -28,8 +28,10 @@ jobs:
           cd modal
           poetry run modal config set-environment main
 
-          echo "Downloading models..."
-          poetry run modal run runner::download
+# TODO: Re-enable when we're confident in the download action bug fix
+#
+#          echo "Downloading models..."
+#          poetry run modal run runner::download
 
           echo "Deploying..."
           poetry run modal deploy runner


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

Something in the volumes is getting corrupted with every reinvocation of the downloader. Turning it off for now in CI so we can still get most of the benefits of CD

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
