### PR TITLE
perf: move large vLLM imports into the image.imports() context manager

### DIFF
--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -3,23 +3,14 @@ from typing import Optional
 
 import modal.gpu
 import sentry_sdk
-from modal import Image
 
-from runner.engines.vllm import VllmEngine, VllmParams
+from runner.engines.vllm import VllmEngine, VllmParams, vllm_image
 from runner.shared.common import stub
 from shared.logging import (
-    add_observability,
     get_logger,
     get_observability_secrets,
 )
 from shared.volumes import does_model_exist, models_path, models_volume
-
-_vllm_image = add_observability(
-    Image.from_registry(
-        "nvidia/cuda:12.1.0-base-ubuntu22.04",
-        add_python="3.10",
-    ).pip_install("vllm==0.2.6", "sentry-sdk==1.39.1")
-)
 
 
 def _make_container(
@@ -74,7 +65,7 @@ def _make_container(
 
     wrap = stub.cls(
         volumes={models_path: models_volume},
-        image=_vllm_image,
+        image=vllm_image,
         # Default CPU memory is 128 on modal. Request more memory for larger
         # windows of vLLM's batch loading weights into GPU memory.
         memory=1024,


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

currently takes 8 to 10s for python to load vllm imports -- should be an easy win to bake into the image

unsure if we need to [enable checkpointing](https://modal.com/docs/guide/checkpointing) to take advantage of this, or if it just works for imports out of the box -- i;ll have to ask modal

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
