### PR TITLE
fix: key error when popping CUDA_VISIBLE_DEVICES env

### DIFF
--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -44,7 +44,7 @@ def _make_container(
                 if num_gpus > 1:
                     # HACK[1-20-2024]: Yesterday, Modal started populating this env var
                     # with GPU UUIDs. This breaks some assumption in Ray, so just unset
-                    os.environ.pop("CUDA_VISIBLE_DEVICES")
+                    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
                     # Patch issue from https://github.com/vllm-project/vllm/issues/1116
                     import ray


### PR DESCRIPTION
modal stopped setting this var & now we're seeing key errors 