### PR TITLE
perf: bump noromaidmixtral to max_containers=3

### DIFF
--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -117,7 +117,7 @@ VllmContainer_NeverSleepNoromaidMixtral8x7B = _make_container(
     num_gpus=2,
     memory=80,
     concurrent_inputs=4,
-    max_containers=2,
+    max_containers=3,
 )
 VllmContainer_JohnDurbinBagel34B = _make_container(
     name="VllmContainer_JohnDurbinBagel34B",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

there were intermittent periods of high backlogs on this model, gonna try a small bump to 3 containers since its popular enough.  dont want it to autoscale unbounded though

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
