### PR TITLE
fix: revert BACKLOG_THRESHOLD from 100 back to 30 following instability

### DIFF
--- a/modal/runner/shared/common.py
+++ b/modal/runner/shared/common.py
@@ -7,6 +7,6 @@ config = Config(
     api_key_id="RUNNER_API_KEY",
 )
 
-BACKLOG_THRESHOLD = 100
+BACKLOG_THRESHOLD = 30
 
 stub = Stub(config.name)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

saw a lot more instability in the last couple hours with this high backlog number.  way more cold starts happening on noromaid, kinda weird

![image](https://github.com/OpenRouterTeam/openrouter-runner/assets/1211977/720f031b-e812-427b-a228-7573c2305151)


reverting it back down to 30 before the weekend to limit confounding variables with other recent changes -- still cant tell that the keep_warm stuff is working :/

<!-- What does this PR do?  -->

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
