### PR TITLE
deps: bump vllm from 0.2.6 to 0.3.3

### DIFF
--- a/modal/runner/engines/vllm.py
+++ b/modal/runner/engines/vllm.py
@@ -27,7 +27,7 @@ vllm_image = add_observability(
     Image.from_registry(
         "nvidia/cuda:12.1.0-base-ubuntu22.04",
         add_python="3.10",
-    ).pip_install("vllm==0.2.6", "sentry-sdk==1.39.1")
+    ).pip_install("vllm==0.3.3", "sentry-sdk==1.39.1")
 )
 
 with vllm_image.imports():


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

<!-- What does this PR do?  -->

currently errors when booting a container though, something broken in modal when using this version:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/pkg/modal/_container_entrypoint.py", line 1020, in <module>
    main(container_args, client)
  File "/pkg/modal/_container_entrypoint.py", line 968, in main
    event_loop.run(call_function_async(function_io_manager, imp_fun))
  File "/pkg/modal/_container_entrypoint.py", line 92, in run
    return self.loop.run_until_complete(task)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/pkg/modal/_container_entrypoint.py", line 740, in call_function_async
    async for input_id, function_call_id, args, kwargs in function_io_manager.run_inputs_outputs.aio(
  File "/pkg/synchronicity/synchronizer.py", line 364, in _run_generator_async
    raise uc_exc.exc from None
  File "/pkg/modal/_container_entrypoint.py", line 389, in run_inputs_outputs
    args, kwargs = self.deserialize(input_pb.args) if input_pb.args else ((), {})
  File "/pkg/modal/_container_entrypoint.py", line 228, in deserialize
    return deserialize(data, self._client)
  File "/pkg/modal/_serialization.py", line 58, in deserialize
    return Unpickler(client, io.BytesIO(s)).load()
  File "/usr/local/lib/python3.10/site-packages/pydantic/main.py", line 864, in __setstate__
    _object_setattr(self, '__pydantic_fields_set__', state['__pydantic_fields_set__'])
KeyError: '__pydantic_fields_set__'
```

### Code of Conduct

- [ ] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I agree to license this contribution under the MIT LICENSE
- [ ] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
