### PR TITLE
perf: serve quantized versions of phi2, neuralchat, and psyfighter1

### DIFF
--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -144,11 +144,11 @@ VllmContainer_JebCarterPsyfighter13B = _make_container(
     concurrent_inputs=32,
 )
 
-_psyfighter2 = "TheBloke/LLaMA2-13B-Psyfighter2-GPTQ"
+# TODO: quantize this one too? avoided for now since it's higher throughput
 VllmContainer_KoboldAIPsyfighter2 = _make_container(
     name="VllmContainer_KoboldAIPsyfighter2",
-    model_name=_psyfighter2,
-    gpu=modal.gpu.A10G(count=1),
+    model_name="KoboldAI/LLaMA2-13B-Psyfighter2",
+    gpu=modal.gpu.A100(count=1, memory=40),
     concurrent_inputs=32,
 )
 
@@ -184,7 +184,6 @@ QUANTIZED_MODELS = {
     "microsoft/phi-2": _phi2,
     "Intel/neural-chat-7b-v3-1": _neural_chat,
     "jebcarter/Psyfighter-13B": _psyfighter,
-    "KoboldAI/LLaMA2-13B-Psyfighter2": _psyfighter2,
     "NeverSleep/Noromaid-v0.1-mixtral-8x7b-Instruct-v3": _noromaid,
     "jondurbin/bagel-34b-v0.2": _bagel,
 }

--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -31,7 +31,9 @@ def _make_container(
     """Helper function to create a container with the given GPU configuration."""
 
     num_gpus = gpu.count
-    if isinstance(gpu, modal.gpu.A100):
+    if isinstance(gpu, modal.gpu.A10G):
+        gpu_type = GPUType.A10G
+    elif isinstance(gpu, modal.gpu.A100):
         gpu_type = GPUType.A100_80G if gpu.memory == 80 else GPUType.A100_40G
     elif isinstance(gpu, modal.gpu.H100):
         gpu_type = GPUType.H100_80G
@@ -118,28 +120,35 @@ def _make_container(
 # Automatically populated by _make_container.
 REGISTERED_CONTAINERS = {}
 
+_phi2 = "TheBloke/phi-2-GPTQ"
 VllmContainer_MicrosoftPhi2 = _make_container(
     name="VllmContainer_MicrosoftPhi2",
-    model_name="microsoft/phi-2",
-    gpu=modal.gpu.A100(count=1, memory=40),
+    model_name=_phi2,
+    gpu=modal.gpu.A10G(count=1),
     concurrent_inputs=120,
 )
+
+_neural_chat = "TheBloke/neural-chat-7b-v3-1-GPTQ"
 VllmContainer_IntelNeuralChat7B = _make_container(
     name="VllmContainer_IntelNeuralChat7B",
-    model_name="Intel/neural-chat-7b-v3-1",
-    gpu=modal.gpu.A100(count=1, memory=40),
+    model_name=_neural_chat,
+    gpu=modal.gpu.A10G(count=1),
     concurrent_inputs=100,
 )
+
+_psyfighter = "TheBloke/Psyfighter-13B-GPTQ"
 VllmContainer_JebCarterPsyfighter13B = _make_container(
     "VllmContainer_JebCarterPsyfighter13B",
-    model_name="jebcarter/Psyfighter-13B",
-    gpu=modal.gpu.A100(count=1, memory=40),
+    model_name=_psyfighter,
+    gpu=modal.gpu.A10G(count=1),
     concurrent_inputs=32,
 )
+
+_psyfighter2 = "TheBloke/LLaMA2-13B-Psyfighter2-GPTQ"
 VllmContainer_KoboldAIPsyfighter2 = _make_container(
     name="VllmContainer_KoboldAIPsyfighter2",
-    model_name="KoboldAI/LLaMA2-13B-Psyfighter2",
-    gpu=modal.gpu.A100(count=1, memory=40),
+    model_name=_psyfighter2,
+    gpu=modal.gpu.A10G(count=1),
     concurrent_inputs=32,
 )
 
@@ -172,6 +181,10 @@ VllmContainer_JohnDurbinBagel34B = _make_container(
 # From the outside, the model name is the original, but internally,
 # we use the quantized model name.
 QUANTIZED_MODELS = {
+    "microsoft/phi-2": _phi2,
+    "Intel/neural-chat-7b-v3-1": _neural_chat,
+    "jebcarter/Psyfighter-13B": _psyfighter,
+    "KoboldAI/LLaMA2-13B-Psyfighter2": _psyfighter2,
     "NeverSleep/Noromaid-v0.1-mixtral-8x7b-Instruct-v3": _noromaid,
     "jondurbin/bagel-34b-v0.2": _bagel,
 }

--- a/modal/runner/containers/vllm_unified.py
+++ b/modal/runner/containers/vllm_unified.py
@@ -108,7 +108,8 @@ VllmContainer_MicrosoftPhi2 = _make_container(
     name="VllmContainer_MicrosoftPhi2",
     model_name=_phi2,
     gpu=modal.gpu.A10G(count=1),
-    concurrent_inputs=120,
+    concurrent_inputs=4,
+    max_containers=5,
 )
 
 _neural_chat = "TheBloke/neural-chat-7b-v3-1-GPTQ"
@@ -116,7 +117,8 @@ VllmContainer_IntelNeuralChat7B = _make_container(
     name="VllmContainer_IntelNeuralChat7B",
     model_name=_neural_chat,
     gpu=modal.gpu.A10G(count=1),
-    concurrent_inputs=100,
+    concurrent_inputs=4,
+    max_containers=5,
 )
 
 _psyfighter = "TheBloke/Psyfighter-13B-GPTQ"
@@ -124,10 +126,11 @@ VllmContainer_JebCarterPsyfighter13B = _make_container(
     "VllmContainer_JebCarterPsyfighter13B",
     model_name=_psyfighter,
     gpu=modal.gpu.A10G(count=1),
-    concurrent_inputs=32,
+    concurrent_inputs=4,
+    max_containers=5,
 )
 
-# TODO: quantize this one too? avoided for now since it's higher throughput
+# TODO: quantize this one too. shipping the others first to limit blast radius
 VllmContainer_KoboldAIPsyfighter2 = _make_container(
     name="VllmContainer_KoboldAIPsyfighter2",
     model_name="KoboldAI/LLaMA2-13B-Psyfighter2",
@@ -163,6 +166,10 @@ VllmContainer_JohnDurbinBagel34B = _make_container(
 # A re-mapping of model names to their respective quantized models.
 # From the outside, the model name is the original, but internally,
 # we use the quantized model name.
+#
+# NOTE: When serving quantized models, the throughput can suffer a ton
+#       at high batch sizes. Read this thread to learn why:
+#       https://github.com/vllm-project/vllm/issues/1002#issuecomment-1712824199
 QUANTIZED_MODELS = {
     "microsoft/phi-2": _phi2,
     "Intel/neural-chat-7b-v3-1": _neural_chat,

--- a/modal/shared/protocol.py
+++ b/modal/shared/protocol.py
@@ -4,12 +4,14 @@ from typing import Final, List, Optional, Union
 from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel
 
+_COST_PER_SECOND_A10G: Final[float] = 0.000306
 _COST_PER_SECOND_A100_40G: Final[float] = 0.001036
 _COST_PER_SECOND_A100_80G: Final[float] = 0.001553
 _COST_PER_SECOND_H100_80G: Final[float] = 0.002125
 
 
 class GPUType(Enum):
+    A10G = "A10G"
     A100_40G = "A100_40G"
     A100_80G = "A100_80G"
     H100_80G = "H100_80G"
@@ -17,6 +19,8 @@ class GPUType(Enum):
     @property
     def cost_per_second(self) -> float:
         match self:
+            case GPUType.A10G:
+                return _COST_PER_SECOND_A10G
             case GPUType.A100_40G:
                 return _COST_PER_SECOND_A100_40G
             case GPUType.A100_80G:

--- a/modal/shared/protocol.py
+++ b/modal/shared/protocol.py
@@ -72,10 +72,6 @@ class Usage(BaseModel):
     prompt_tokens: int
     completion_tokens: int
 
-    duration: float
-    gpu_type: GPUType
-    gpu_count: int
-
 
 class ResponseBody(BaseModel):
     text: str

--- a/modal/shared/protocol.py
+++ b/modal/shared/protocol.py
@@ -1,32 +1,7 @@
-from enum import Enum
-from typing import Final, List, Optional, Union
+from typing import List, Optional, Union
 
 from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel
-
-_COST_PER_SECOND_A10G: Final[float] = 0.000306
-_COST_PER_SECOND_A100_40G: Final[float] = 0.001036
-_COST_PER_SECOND_A100_80G: Final[float] = 0.001553
-_COST_PER_SECOND_H100_80G: Final[float] = 0.002125
-
-
-class GPUType(Enum):
-    A10G = "A10G"
-    A100_40G = "A100_40G"
-    A100_80G = "A100_80G"
-    H100_80G = "H100_80G"
-
-    @property
-    def cost_per_second(self) -> float:
-        match self:
-            case GPUType.A10G:
-                return _COST_PER_SECOND_A10G
-            case GPUType.A100_40G:
-                return _COST_PER_SECOND_A100_40G
-            case GPUType.A100_80G:
-                return _COST_PER_SECOND_A100_80G
-            case GPUType.H100_80G:
-                return _COST_PER_SECOND_H100_80G
 
 
 # https://github.com/vllm-project/vllm/blob/320a622ec4d098f2da5d097930f4031517e7327b/vllm/sampling_params.py#L7-L52


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

all of em are downloaded on dev, and initial tests show they function on a single A10G

~~i still need to run experiments to pick an appropriate `concurrent_inputs` parameter for the model -- so we can see how actual performance differs from original models & config~~ 

**edit: ahh [this discussion has great info](https://github.com/vllm-project/vllm/issues/1002#issuecomment-1712824199).. perf suffers greatly at 8+ batch size**

uses the following from TheBloke:
* https://huggingface.co/TheBloke/phi-2-GPTQ
* https://huggingface.co/TheBloke/neural-chat-7B-v3-1-GPTQ
* https://huggingface.co/TheBloke/Psyfighter-13B-GPTQ
* https://huggingface.co/TheBloke/LLaMA2-13B-Psyfighter2-GPTQ

### Code of Conduct

- [ ] I agree to follow this project's [Code of Conduct](https://github.com/OpenRouterTeam/openrouter-runner/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I agree to license this contribution under the MIT LICENSE
- [ ] I checked the [current PR](https://github.com/OpenRouterTeam/openrouter-runner/pulls) for duplication.
